### PR TITLE
feat: add support for permissions

### DIFF
--- a/src/AzurePimcoreBundle/AzurePimcoreBundle.php
+++ b/src/AzurePimcoreBundle/AzurePimcoreBundle.php
@@ -17,6 +17,7 @@ namespace AzurePimcoreBundle\AzurePimcoreBundle;
 
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
 use \Pimcore\Model\User\Permission\Definition;
+use Pimcore\Db;
 
 class AzurePimcoreBundle extends AbstractPimcoreBundle {
    
@@ -26,9 +27,27 @@ class AzurePimcoreBundle extends AbstractPimcoreBundle {
             '/bundles/azurepimcore/js/pimcore/azure.js'
         ];
     }
+
+    public function getDescription()
+    {
+        return 'Pushes Pimcore assets to Microsoft Azure Blob Storage';
+    }
+
+    public function getVersion()
+    {
+        return 'v1.4';
+    }
     
     public function getInstaller() {
         $this->getJsPaths();
         $this->getCssPaths();  
+    }
+
+    public function getInstaller()
+    {
+        $script = "INSERT IGNORE INTO users_permission_definitions (`key`) VALUES ('azure_blob_storage_bundle');";
+
+        $db = Db::get();
+        $db->query($script);
     }
 }

--- a/src/AzurePimcoreBundle/Controller/AzureSettingController.php
+++ b/src/AzurePimcoreBundle/Controller/AzureSettingController.php
@@ -71,7 +71,7 @@ class AzureSettingController extends FrontendController {
         }else{
             $array = array('success' => false);
             $response = new Response(json_encode($array), 401);
-            $response - > headers - > set('Content-Type', 'application/json');
+            $response->headers->set('Content-Type', 'application/json');
       
             return $response;
         }
@@ -110,7 +110,7 @@ class AzureSettingController extends FrontendController {
         }else{
             $array = array('success' => false);
             $response = new Response(json_encode($array), 401);
-            $response - > headers - > set('Content-Type', 'application/json');
+            $response->headers->set('Content-Type', 'application/json');
       
             return $response;
         }

--- a/src/AzurePimcoreBundle/Resources/public/js/pimcore/startup.js
+++ b/src/AzurePimcoreBundle/Resources/public/js/pimcore/startup.js
@@ -14,22 +14,24 @@ pimcore.plugin.pimcoreAzureBundle = Class.create(pimcore.plugin.admin, {
     },
 
     pimcoreReady: function (params, broker) {
+        if(pimcore.currentuser.permissions.indexOf("azure_blob_storage_bundle") >= 0) {
             var settingsMenu = new Ext.Action({
-            text: 'The Azure Container Configurations',
-            iconCls: 'pimcore_icon_gridconfig_class_attributes',
-            handler: function () {
-                var dataExportMainTab = Ext.get("pimcore_settings_azure");
-                if (dataExportMainTab) {
-                    var tabPanel = Ext.getCmp("pimcore_panel_tabs");
-                    tabPanel.setActiveItem("pimcore_settings_azure");
-                } else {
-                    azuretab = new pimcore.plugin.azure();
+                text: 'The Azure Container Configurations',
+                iconCls: 'pimcore_icon_gridconfig_class_attributes',
+                handler: function () {
+                    var dataExportMainTab = Ext.get("pimcore_settings_azure");
+                    if (dataExportMainTab) {
+                        var tabPanel = Ext.getCmp("pimcore_panel_tabs");
+                        tabPanel.setActiveItem("pimcore_settings_azure" );
+                    } else {
+                        azuretab = new pimcore.plugin.azure();
+                    }
                 }
-            }
-        });
-
-        if (layoutToolbar.settingsMenu)
-            layoutToolbar.settingsMenu.add(settingsMenu);
+            });
+    
+            if (layoutToolbar.settingsMenu)
+                layoutToolbar.settingsMenu.add(settingsMenu);
+        }
     },
 });
 


### PR DESCRIPTION
Hello,

this is as PR in order to add support for permissions so only the users of a certain role can access the the bundle configuration.

The logic implementation was added by using the official Pimcore's documentation on [how to add your own permissions](https://pimcore.com/docs/pimcore/current/Development_Documentation/Extending_Pimcore/Add_Your_Own_Permissions.html).

I've also added logic in the installer so it has a description and a version, this will also add an entry to the table `users_permission_definitions` with `azure_blob_storage_bundle` if it doesn't exists.